### PR TITLE
This include is required in newer versions of libavformat/libavcodec

### DIFF
--- a/gizmo/media/stream.h
+++ b/gizmo/media/stream.h
@@ -7,6 +7,7 @@
 extern "C"
 {
 #include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
 }
 
 


### PR DESCRIPTION
This include seems to be required when compiled with newer versions of ffmpeg-dev/libavcodec/libavformat.